### PR TITLE
Migrate adapster to jitpack.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter() // adapster library has not migrated yet
+        maven { url = uri("https://jitpack.io") }
+        //jcenter() // adapster library has not migrated yet
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -96,7 +96,7 @@ object deps {
     const val cardView = "androidx.cardview:cardview:${versions.cardView}"
     const val browser = "androidx.browser:browser:${versions.browser}"
     const val recyclerView = "androidx.recyclerview:recyclerview:${versions.recyclerView}"
-    const val adapster = "com.arthurivanets.adapster:adapster:${versions.adapster}"
+    const val adapster = "com.github.arthur3486.adapster:adapster:${versions.adapster}"
     const val annotations = "androidx.annotation:annotation:${versions.annotations}"
     const val coreKtx = "androidx.core:core-ktx:${versions.coreKtx}"
     const val commonsKtx = "com.paulrybitskyi.commons:commons-ktx:${versions.commonsKtx}"


### PR DESCRIPTION
I think migrating adapster to jitpack will be a better workaround since jitpack won't shutdown anytime soon, but jcenter will. 